### PR TITLE
Cambiar de `opticrd` a `ogticrd` en la dirección a GitHub

### DIFF
--- a/components/header-menu.tsx
+++ b/components/header-menu.tsx
@@ -25,7 +25,7 @@ export default function HeaderMenu() {
     {
       label: t.header.menu.github,
 
-      path: 'https://github.com/opticrd/',
+      path: 'https://github.com/ogticrd/',
       external: true,
     },
   ]


### PR DESCRIPTION
`opticrd` no existe, `ogticrd` es el nombre correcto.